### PR TITLE
Fv add args to manage dockerfile versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,26 @@
 # Elixir + Phoenix
+ARG EX_VERSION=latest
 
-FROM elixir:1.6.1
+FROM elixir:$EX_VERSION
 
 # Install debian packages
 RUN apt-get update
 RUN apt-get install --yes build-essential inotify-tools postgresql-client
 
 # Install Phoenix packages
+ARG PHX_VERSION=1.5.6
 RUN mix local.hex --force
 RUN mix local.rebar --force
-RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phx_new.ez
+RUN mix archive.install hex phx_new $PHX_VERSION
 
 # Install node
-RUN curl -sL https://deb.nodesource.com/setup_6.x -o nodesource_setup.sh
+ARG NODE_VERSION=setup_15
+RUN curl -sL https://deb.nodesource.com/$NODE_VERSION.x -o nodesource_setup.sh
 RUN bash nodesource_setup.sh
 RUN apt-get install nodejs
 
 WORKDIR /app
-EXPOSE 4000
+
+# Set port as argument
+ARG PORT=4000
+EXPOSE $PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,4 @@ RUN bash nodesource_setup.sh
 RUN apt-get install nodejs
 
 WORKDIR /app
-
-# Set port as argument
-ARG PORT=4000
-EXPOSE $PORT
+EXPOSE 4000

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ## What you get
 
-* One-line dev environment setup: `docker-compose up`. It creates the database, does the Dialyzer pre-work (if the project has [Dialyxer](https://github.com/jeremyjh/dialyxir) installed), and everything else.
-* Development-oriented config: Source code is mounted so that changes in the container appear on the host, and vice-versa.
-* Fast re-builds because the `DOCKERFILE` is written to help Docker cache the images.
-* Syncing with Postgres startup delay.
-* All the crappy little dependencies installed.
-* No weird hacks.
+- One-line dev environment setup: `docker-compose up`. It creates the database, does the Dialyzer pre-work (if the project has [Dialyxer](https://github.com/jeremyjh/dialyxir) installed), and everything else.
+- Development-oriented config: Source code is mounted so that changes in the container appear on the host, and vice-versa.
+- Fast re-builds because the `DOCKERFILE` is written to help Docker cache the images.
+- Syncing with Postgres startup delay.
+- All the crappy little dependencies installed.
+- No weird hacks.
 
-Uses Elixir 1.6.1, Phoenix 1.3.0, and latest Postgres. These are the latest versions as of 2018-02-02. Tested on MacOS and Fedora Linux, because that's what I happen to use. This is my configuration I develop with.
+The Dockerfile and docker-compose file now accept Elixir, Node, Postgres and Node versions thru arguments. check the files for more info.
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - All the crappy little dependencies installed.
 - No weird hacks.
 
-The Dockerfile and docker-compose file now accept Elixir, Node, Postgres and Node versions thru arguments. check the files for more info.
+The Dockerfile and docker-compose file now accept Elixir, Node and Postgres versions thru arguments. check the files for more info.
 
 ## Instructions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,20 @@
-version: '3.2'
+version: "3.2"
 services:
   db:
     image: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - db:/var/lib/postgresql/data
 
   web:
-    build: .
+    build:
+      context: .
+      args:
+        EX_VERSION: latest
+        PHX_VERSION: 1.5.6
+        NODE_VERSION: setup_15
+        PORT: 4000
     volumes:
       - type: bind
         source: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
         EX_VERSION: latest
         PHX_VERSION: 1.5.6
         NODE_VERSION: setup_15
-        PORT: 4000
     volumes:
       - type: bind
         source: .


### PR DESCRIPTION
This helps manage future updates of elixir, phoenix and node ans make the repo more timeless